### PR TITLE
Fix to use alias

### DIFF
--- a/terraform/dnsimple_record.tf
+++ b/terraform/dnsimple_record.tf
@@ -83,10 +83,10 @@ resource "dnsimple_record" "main-from8-url" {
     ttl    = 300
 }
 
-resource "dnsimple_record" "panada-cname" {
+resource "dnsimple_record" "panada-alias" {
     domain = "panda-meets-panda.com"
     name   = ""
     value  = "sync-msg-api-prod-nginx-260385198.ap-northeast-1.elb.amazonaws.com"
-    type   = "CNAME"
+    type   = "ALIAS"
     ttl    = "3600"
 }


### PR DESCRIPTION
## Why

https://circleci.com/gh/creasty/creasty-infra/60?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

```
Error applying plan:

1 error(s) occurred:

* dnsimple_record.panada-cname: Failed to create DNSimple Record: Error creating record: API Error: name errors: can't be blank. Consider using an ALIAS instead., base errors: CNAME must be the only record on a subdomain

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
make: *** [apply] Error 1
```

cc @tan-z-tan